### PR TITLE
Only focus subscription URL for "Add".

### DIFF
--- a/cc/res/layout/edit_subscription.xml
+++ b/cc/res/layout/edit_subscription.xml
@@ -5,10 +5,15 @@
 	<ScrollView android:layout_width="fill_parent"
 		android:layout_height="fill_parent">
 
+                <!-- Focus control; see discussion here:
+                     http://stackoverflow.com/questions/1555109/stop-edittext-from-gaining-focus-at-activity-startup
+                     -->
+
 		<LinearLayout
 		    xmlns:android="http://schemas.android.com/apk/res/android"
 		    android:layout_width="fill_parent"
 		    android:layout_height="fill_parent"
+		    android:focusableInTouchMode="true"
 		    android:orientation="vertical" >
 
 		    <TextView

--- a/cc/src/com/jadn/cc/ui/SubscriptionEdit.java
+++ b/cc/src/com/jadn/cc/ui/SubscriptionEdit.java
@@ -121,7 +121,10 @@ public class SubscriptionEdit extends BaseActivity implements Runnable {
 			}
 		}
 		
-		
+		if (getIntent().hasExtra("focus")) {
+			findViewById(R.id.editsite_url).requestFocus();
+                }
+
 		if (getIntent().hasExtra("subscription")) {
 			currentSub = (Subscription) getIntent().getExtras().get(
 					"subscription");

--- a/cc/src/com/jadn/cc/ui/Subscriptions.java
+++ b/cc/src/com/jadn/cc/ui/Subscriptions.java
@@ -142,7 +142,9 @@ public class Subscriptions extends BaseActivity {
 	@Override
 	public boolean onMenuItemSelected(int featureId, MenuItem item) {
 		if (item.getItemId() == R.id.addSubscription) {
-			startActivityForResult(new Intent(this, SubscriptionEdit.class), Integer.MAX_VALUE);
+			Intent addIntent = new Intent(this, SubscriptionEdit.class);
+			addIntent.putExtra("focus", "This value is ignored; only the presence of the key matters.");
+			startActivityForResult(addIntent, Integer.MAX_VALUE);
 			return true;
 		}
 		if (item.getItemId() == R.id.deleteAllSubscriptions) {


### PR DESCRIPTION
Hi again Bob,

Here's a small thing that's been bugging me.  Perhaps it bugs you and/or others too.

Whenever you edit a subscription, the URL text box gets the focus.  So the keyboard jumps onto the screen.  Usually, that's not what I want.

You can get to this activity in one of three ways:
- From the subscription list (`Edit`); in which case we probably don't want to edit the URL, rather change one of the other settings.  So don't focus the URL.
- From the `Add` entry on the subscription list menu; in which case it _does_ make sense to focus the URL; that's probably where the user will type/paste next.
- From externally; in which case we already have a URL, so we're unlikely to want to change it; so don't focus it.

I promise.  After this, I have just one change I'm interested in proposing.  Well, for the time being.  So I'll be off your back soon.

Thanks for the great work!

Steve
